### PR TITLE
Fix random background selection

### DIFF
--- a/src/apps/seelen_wall/app.tsx
+++ b/src/apps/seelen_wall/app.tsx
@@ -24,7 +24,7 @@ export function App() {
       if (backgrounds.length > 1) {
         animate(scope.current, { opacity: 0.1 }).then(() => {
           if (randomize) {
-            setCurrentBg(Math.floor(Math.random() * (backgrounds.length - 1)));
+            setCurrentBg(Math.floor(Math.random() * backgrounds.length));
           } else {
             setCurrentBg((currentIdx) => (currentIdx + 1) % backgrounds.length);
           }


### PR DESCRIPTION
## Summary
- ensure the last wallpaper can be chosen when randomizing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b5f8618ac833387f13a0fba9d5f46

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where the last background was not selectable when randomizing backgrounds. All backgrounds are now included in the random selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->