### PR TITLE
Fix typo in UWP helper function name

### DIFF
--- a/src/background/modules/notifications/application.rs
+++ b/src/background/modules/notifications/application.rs
@@ -26,7 +26,7 @@ use windows::{
 use crate::{
     error_handler::Result,
     event_manager, log_error,
-    modules::uwp::get_hightest_quality_posible,
+    modules::uwp::get_highest_quality_possible,
     seelen::get_app_handle,
     trace_lock,
     utils::{convert_file_to_src, icon_extractor::extract_and_save_icon_umid, spawn_named_thread},
@@ -211,7 +211,7 @@ impl NotificationManager {
                 "http" | "https" => {}
                 "ms-appx" | "ms-appx-web" => {
                     let path = package_path.clone()?.join(uri_path);
-                    if let Some((path, _)) = get_hightest_quality_posible(&path) {
+                    if let Some((path, _)) = get_highest_quality_possible(&path) {
                         log::debug!("  Resolved path: {}", path.display());
                         image.src = convert_file_to_src(&path);
                     } else {

--- a/src/background/modules/uwp/mod.rs
+++ b/src/background/modules/uwp/mod.rs
@@ -29,7 +29,7 @@ lazy_static! {
 }
 
 // returns light and dark icons
-pub fn get_hightest_quality_posible(icon_path: &Path) -> Option<(PathBuf, PathBuf)> {
+pub fn get_highest_quality_possible(icon_path: &Path) -> Option<(PathBuf, PathBuf)> {
     let filename = icon_path.file_stem()?.to_str()?;
     let extension = icon_path.extension()?.to_str()?;
 
@@ -124,7 +124,7 @@ impl UwpManager {
         let app_manifest = match manifest.get_app(&app_info.Id()?.to_string_lossy()) {
             Some(app) => app,
             None => {
-                return get_hightest_quality_posible(&store_logo)
+                return get_highest_quality_possible(&store_logo)
                     .ok_or("Could not find package logo path".into())
             }
         };
@@ -132,9 +132,9 @@ impl UwpManager {
         let app_logo_44 = package_path.join(&app_manifest.visual_elements.logo_44);
         let app_logo_150 = package_path.join(&app_manifest.visual_elements.logo_150);
 
-        get_hightest_quality_posible(&app_logo_44)
-            .or_else(|| get_hightest_quality_posible(&app_logo_150))
-            .or_else(|| get_hightest_quality_posible(&store_logo))
+        get_highest_quality_possible(&app_logo_44)
+            .or_else(|| get_highest_quality_possible(&app_logo_150))
+            .or_else(|| get_highest_quality_possible(&store_logo))
             .ok_or_else(|| format!("App icon not found for {app_umid}").into())
     }
 }


### PR DESCRIPTION
## Summary
- rename `get_hightest_quality_posible` to `get_highest_quality_possible`
- update all call sites

## Testing
- `cargo check` *(fails: glib-2.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b5f8683bc833381a9c1f9d1d5a259

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected a typographical error in a function name related to resolving image paths in notifications and icon handling, ensuring consistency across the app. No changes to functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->