### PR TITLE
Fix comment typos in Windows API file

### DIFF
--- a/src/background/windows_api/event_window.rs
+++ b/src/background/windows_api/event_window.rs
@@ -102,7 +102,7 @@ unsafe fn _create_background_window(done: &crossbeam_channel::Sender<()>) -> Res
         std::thread::sleep(std::time::Duration::from_millis(100));
     });
 
-    // register window to recieve device notifications for monitor changes
+    // register window to receive device notifications for monitor changes
     {
         let mut notification_filter = DEV_BROADCAST_DEVICEINTERFACE_W {
             dbcc_size: std::mem::size_of::<DEV_BROADCAST_DEVICEINTERFACE_W>() as u32,
@@ -118,7 +118,7 @@ unsafe fn _create_background_window(done: &crossbeam_channel::Sender<()>) -> Res
         )?;
     }
 
-    // register window to recieve shell events
+    // register window to receive shell events
     {
         RegisterShellHookWindow(hwnd).ok().filter_fake_error()?;
         let msg = WindowsString::from("SHELLHOOK");


### PR DESCRIPTION
## Summary
- fix typo "recieve" -> "receive" in event_window.rs comments

## Testing
- `cargo test --quiet` *(fails: glib-2.0.pc missing)*
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b5f873aa08333b652c5a949de3c4f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected spelling errors in comments to improve clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->