### PR TITLE
Add variable convention tests

### DIFF
--- a/src/apps/shared/schemas/index.test.ts
+++ b/src/apps/shared/schemas/index.test.ts
@@ -56,4 +56,63 @@ describe('VariableConvention', () => {
     expect(VariableConvention.deepKeyParser(camelObject, VariableConvention.camelToSnake)).toEqual(snakeObject);
     expect(VariableConvention.deepKeyParser(snakeObject, VariableConvention.snakeToCamel)).toEqual(camelObject);
   });
+
+  test('camelToUser', () => {
+    expect(VariableConvention.camelToUser('helloWorld')).toBe('hello world');
+    expect(VariableConvention.camelToUser('HelloWorld')).toBe('hello world');
+    expect(VariableConvention.camelToUser('testingCamelCaseText')).toBe('testing camel case text');
+    expect(VariableConvention.camelToUser('helloWorld123')).toBe('hello world 1 2 3');
+  });
+
+  test('fromSnakeToCamel', () => {
+    const snake = {
+      hello_world: {
+        my_world: 1,
+      },
+      array_test: [
+        {
+          deep_case: 'text',
+        },
+      ],
+    };
+
+    const camel = {
+      helloWorld: {
+        myWorld: 1,
+      },
+      arrayTest: [
+        {
+          deepCase: 'text',
+        },
+      ],
+    };
+
+    expect(VariableConvention.fromSnakeToCamel(snake)).toEqual(camel);
+  });
+
+  test('fromCamelToSnake', () => {
+    const camel = {
+      helloWorld: {
+        myWorld: 1,
+      },
+      arrayTest: [
+        {
+          deepCase: 'text',
+        },
+      ],
+    };
+
+    const snake = {
+      hello_world: {
+        my_world: 1,
+      },
+      array_test: [
+        {
+          deep_case: 'text',
+        },
+      ],
+    };
+
+    expect(VariableConvention.fromCamelToSnake(camel)).toEqual(snake);
+  });
 });


### PR DESCRIPTION
## Summary
- extend VariableConvention tests with camelToUser, fromSnakeToCamel and fromCamelToSnake

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b5f886d508333a4a80ea1fab19d24

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added new test cases to verify string and object key conversions between camelCase and snake_case, including support for nested objects and arrays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->